### PR TITLE
issue 15: cookie consent pop up 

### DIFF
--- a/pages/landing.html
+++ b/pages/landing.html
@@ -8,6 +8,24 @@
     <link href="css/main.css" rel="stylesheet">
     <title>vault-express</title>
   </head>
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
+  <script>
+  window.addEventListener("load", function(){
+  window.cookieconsent.initialise({
+	"palette": {
+	  "popup": {
+		"background": "#237afc"
+	  },
+	  "button": {
+		"background": "#fff",
+		"text": "#237afc"
+	  }
+	},
+	"theme": "classic",
+	"position": "bottom-right"
+  })});
+  </script>
   <body>
     <noscript>
       You need to enable JavaScript to run this app.
@@ -24,5 +42,6 @@
         </div>
       </div>
     </div>
+    <script src ="/cookie.js"></script>
   </body>
 </html>

--- a/pages/landing.html
+++ b/pages/landing.html
@@ -42,6 +42,5 @@
         </div>
       </div>
     </div>
-    <script src ="/cookie.js"></script>
   </body>
 </html>


### PR DESCRIPTION
this uses an inline script inside of landing.html to insert the CDN for cookieconsent plug. There is an option to use cookieconsent as a dependency but it was throwing a MIME type error which i could not figure out how to resolve. This CDN also allows the functionality for a user to refuse to use cookies which could be useful in the future. 